### PR TITLE
Fix payroll content syntax error for railway deploy

### DIFF
--- a/src/components/hrd-content/PayrollContent.tsx
+++ b/src/components/hrd-content/PayrollContent.tsx
@@ -318,7 +318,7 @@ export const PayrollContent = () => {
       // Reset flag setelah selesai (success atau error)
       setIsCalculating(false);
     }
-  };
+  }, [form.employee_id, manualDeductions]);
 
 
 
@@ -347,9 +347,7 @@ export const PayrollContent = () => {
     }
   }, [payrollComponents, form.employee_id, form.gross_salary, isCalculating, calculatePayrollComponents]); // Tambahkan calculatePayrollComponents, bukan employee_id
 
-
-
-    const handleFormChange = (field: string, value: any) => {
+  const handleFormChange = (field: string, value: any) => {
     console.log('Form change:', { field, value, currentForm: form });
     
     if (field === 'employee_id') {


### PR DESCRIPTION
Fixes build error in `PayrollContent.tsx` by adding missing `useCallback` dependency array and correcting indentation.

The build failed with "Expected ')' but found ';'" because the `useCallback` hook for `calculatePayrollComponents` was missing its required dependency array, leading to a syntax error. This PR adds the dependency array and corrects minor indentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-283ff57c-c58e-4deb-8bc2-64f675c66502">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-283ff57c-c58e-4deb-8bc2-64f675c66502">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

